### PR TITLE
Fix irrelevant tags

### DIFF
--- a/src/main/java/seedu/address/logic/commands/AddCommand.java
+++ b/src/main/java/seedu/address/logic/commands/AddCommand.java
@@ -41,8 +41,8 @@ public class AddCommand extends Command {
             + PREFIX_ADDRESS + "311, Clementi Ave 2, #02-25 "
             + PREFIX_DATE + "01-03-2026 "
             + PREFIX_STATUS + "Pending "
-            + PREFIX_TAG + "friends "
-            + PREFIX_TAG + "owesMoney";
+            + PREFIX_TAG + "InterviewRound2 "
+            + PREFIX_TAG + "BigTech";
 
     public static final String MESSAGE_SUCCESS = "New application added: %1$s";
     public static final String MESSAGE_DUPLICATE_APPLICATION = "This application already exists in the address book";


### PR DESCRIPTION
# Description

Updated the add command example to replace irrelevant tags (`t/friends`, `t/owesMoney`) with job application relevant tags.

Before:
<img width="1514" height="146" alt="image" src="https://github.com/user-attachments/assets/4cd48ff2-2aa6-4d32-8ea1-5ec0857c8bf8" />

After: 
<img width="1627" height="149" alt="image" src="https://github.com/user-attachments/assets/3ffa9857-5bfc-4b75-9066-3f0d01c1a160" />

Fixes: #130 